### PR TITLE
build: bump CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project(dht C)
 
 add_library(${PROJECT_NAME} STATIC


### PR DESCRIPTION
CMake < 3.5 compatibility has been removed from CMake 4.0 and CMake < 3.10 compatibility has been deprecated in CMake 3.31.

https://cmake.org/cmake/help/latest/release/4.0.html
https://cmake.org/cmake/help/latest/release/3.31.html