### PR TITLE
bump cmake_minimum_required to 3.16.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.16.3)
 project(dht C)
 
 add_library(${PROJECT_NAME} STATIC


### PR DESCRIPTION
The macOS build issue:

>CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.

This is resolved by adopting either CMake 3.5, or align with Transmission as CMake 3.16.3 as done by https://github.com/transmission/transmission/pull/7576

This PR is for https://github.com/transmission/dht instead of https://github.com/jech/dht because the CMakeLists.txt is exclusive to the Transmission fork and was added previously by 015585510e402a057ec17142711ba2b568b5fd62