### PR TITLE
Pick up the two DHT fixes merged upstream

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -2318,17 +2318,17 @@ dht_periodic(const void *buf, size_t buflen,
     }
 
     if(now.tv_sec >= confirm_nodes_time) {
-        int soon = 0;
+        int soon, soon4, soon6;
 
-        soon |= bucket_maintenance(AF_INET);
-        soon |= bucket_maintenance(AF_INET6);
+        soon4 = bucket_maintenance(AF_INET);
+        soon6 = bucket_maintenance(AF_INET6);
 
-        if(!soon) {
-            if(mybucket_grow_time >= now.tv_sec - 150)
-                soon |= neighbourhood_maintenance(AF_INET);
-            if(mybucket6_grow_time >= now.tv_sec - 150)
-                soon |= neighbourhood_maintenance(AF_INET6);
-        }
+        if(!soon4 && mybucket_grow_time >= now.tv_sec - 150)
+            soon4 |= neighbourhood_maintenance(AF_INET);
+        if(!soon6 && mybucket6_grow_time >= now.tv_sec - 150)
+            soon6 |= neighbourhood_maintenance(AF_INET6);
+
+        soon = soon4 | soon6;
 
         /* Given the timeouts in bucket_maintenance, with a 22-bucket
            table, worst case is a ping every 18 seconds (22 buckets plus

--- a/dht.c
+++ b/dht.c
@@ -1243,7 +1243,7 @@ search_step(struct search *sr, dht_callback_t *callback, void *closure)
         return;
     }
 
-    if(sr->step_time + DHT_SEARCH_RETRANSMIT >= now.tv_sec)
+    if(sr->step_time + DHT_SEARCH_RETRANSMIT > now.tv_sec)
         return;
 
     j = 0;


### PR DESCRIPTION
Two fixes from `jech/dht@master`, cherry-picked unmodified with upstream authorship preserved.

- [`c723931`](https://github.com/jech/dht/commit/c723931) — "Run the search step when it is exactly time" (jech/dht#52), authored by Greg Hazel
- [`be5684a`](https://github.com/jech/dht/commit/be5684a) — "Don't let one family's bucket maintenance starve the other's" (jech/dht#51)

With these, `dht.c` on this branch is identical to `jech/dht@master` except for the `dht_uninit(void)` declaration from [`0bbb8f4`](https://github.com/jech/dht/commit/0bbb8f4) — see the note at the end.

### Why the starvation fix matters here

Without `be5684a`, `dht_periodic` gates neighbourhood maintenance for *both* address families on a single `soon` flag that *either* family's `bucket_maintenance` can set. Bucket maintenance re-confirms nodes already in the table; neighbourhood maintenance is what *grows* it. So a family whose nodes never answer stops the other family from finding anyone.

A family gets stuck there permanently rather than gradually. `buckets6` is `calloc`ed so `b->time` starts at 0, and with `max_count == 128` the root bucket is already stale on the first `dht_periodic` (`to = MAX(600 / (128/8), 30) == 37`). `b->time` only advances in `new_node()` under `confirm == 2`, a reply to our own query. If nothing in that family ever replies, `bucket_maintenance` returns 1 on every round for ever.

This needs no unusual configuration: a host with no working route for one family still *learns* that family's addresses, because they arrive in the `nodes`/`nodes6` of the other family's replies. Transmission reaches it because `tr_dht_impl` creates a single dual-family instance — `libtransmission/tr-dht.cc:162` passes both `udp4_socket_` and `udp6_socket_` to `dht_init()`.

Offline harness, one host, no public DHT traffic: three unresponsive IPv6 nodes inserted with `dht_insert_node`, one live local IPv4 responder, 140 s per arm.

| arm | rounds | IPv6 bucket maint. | **IPv4 neighbourhood maint.** | IPv4 bucket maint. |
|---|---|---|---|---|
| without the fix, 3 unresponsive IPv6 nodes | 19 | 19/19 | **0** | 4 |
| with the fix, same 3 nodes | 15 | 15/15 | **14/15** | 1 |
| control: without the fix, no IPv6 nodes | 16 | 0 | **15/16** | 1 |

The IPv6 half is equally dead in the first two arms, which isolates the scheduling as the only variable. Within each family either bucket or neighbourhood maintenance runs, never both, so a round still sends at most two maintenance queries — the query budget is unchanged.

### The search_step fix

Without `c723931`, `search_step` returns early unless `now.tv_sec` is strictly greater than `sr->step_time + DHT_SEARCH_RETRANSMIT`, so a wakeup scheduled for exactly that second can only return without sending. Since `dht_periodic` schedules the next search wakeup at `step_time + DHT_SEARCH_RETRANSMIT + random() % DHT_SEARCH_RETRANSMIT`, one draw in ten lands on the boundary. Measured over 180 s: 4 of 49 `search_step` entries are exactly-on-time no-ops without it, 0 of 50 with it, and genuinely-early returns stay at 10 either way.

### On `0bbb8f4`

I have deliberately left it out to keep this reviewable as two named upstream fixes. It is unrelated to both, and taking it would make this branch exactly `jech/dht@master` plus your two build commits. Happy to add it here or send it separately, whichever you prefer — or to leave the branch as-is.

Filed alongside transmission/transmission#9097, which describes the starvation bug against Transmission specifically.
